### PR TITLE
Add glib

### DIFF
--- a/org.gnome.baobab.json
+++ b/org.gnome.baobab.json
@@ -20,6 +20,17 @@
     ],
     "modules": [
         {
+            "name" : "glib",
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/glib.git",
+                    "commit" : "724df436166b80a1c172d7551d3405620038d79a"
+                }
+            ]
+        },
+        {
             "name": "baobab",
             "buildsystem": "meson",
             "sources": [


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/glib/-/issues/2629, this should be
removed once the related PR is backported to 2.72 and lands on the
stable runtime.

cc: @BrainBlasted 