### PR TITLE
Add permission to read flatpak dir

### DIFF
--- a/org.gnome.baobab.json
+++ b/org.gnome.baobab.json
@@ -10,6 +10,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--filesystem=host",
+        "--filesystem=~/.var/app",
         "--metadata=X-DConf=migrate-path=/org/gnome/baobab/",
         "--talk-name=org.gtk.vfs.*",
         "--filesystem=xdg-run/gvfs",


### PR DESCRIPTION
It can be useful e.g. when you have games installed inside Flatpak Steam
or Bottles and you want to calculate the occupied size